### PR TITLE
Add extensible subtitle tracks to dasha Input

### DIFF
--- a/src/hls/hls-subtitles.ts
+++ b/src/hls/hls-subtitles.ts
@@ -25,7 +25,7 @@ const TAG_PLAYLIST_TYPE = '#EXT-X-PLAYLIST-TYPE:';
 const AES_128_BLOCK_SIZE = 16;
 const IV_STRING_REGEX = /^0[xX][0-9a-fA-F]+$/;
 
-const DEFAULT_TRACK_DISPOSITION: TrackDisposition = {
+export const DEFAULT_TRACK_DISPOSITION: TrackDisposition = {
   commentary: false,
   default: true,
   forced: false,
@@ -35,7 +35,7 @@ const DEFAULT_TRACK_DISPOSITION: TrackDisposition = {
   visuallyImpaired: false,
 };
 
-type SourceWithRootPath = {
+export type SourceWithRootPath = {
   rootPath: string;
   _options?: { requestInit?: RequestInit };
   _url?: string | URL | Request;
@@ -258,7 +258,7 @@ const loadPlaylistText = async (source: SourceWithRootPath, path: string) => {
   };
 };
 
-const detectSubtitleCodecFromUri = async (source: SourceWithRootPath, uri: string) => {
+export const detectSubtitleCodecFromUri = async (source: SourceWithRootPath, uri: string) => {
   const fromPath = parseDetectedSubtitleCodec(inferSubtitleCodecStringFromPath(uri));
   if (fromPath) {
     return fromPath;
@@ -359,7 +359,7 @@ const createSequenceIv = (sequenceNumber: number) => {
   return iv;
 };
 
-class HlsSubtitlePlaylist implements HlsSegmentedInput {
+export class HlsSubtitlePlaylist implements HlsSegmentedInput {
   segments: HlsSegment[] = [];
   #source: SourceWithRootPath;
   #playlistPath: string;
@@ -656,6 +656,97 @@ class HlsSubtitlePlaylist implements HlsSegmentedInput {
   }
 }
 
+class ExternalSubtitleSegmentedInput implements HlsSegmentedInput {
+  segments: HlsSegment[] = [];
+  #source: SourceWithRootPath;
+  #rootPath: string;
+  #delegate:
+    | (HlsSegmentedInput & {
+        getDurationFromMetadata(options: DurationMetadataRequestOptions): Promise<number | null>;
+        getLiveRefreshInterval(): Promise<number | null>;
+        isRelativeToUnixEpoch(): Promise<boolean>;
+      })
+    | null = null;
+  #loadPromise: Promise<void> | null = null;
+
+  constructor(source: SourceWithRootPath, rootPath: string) {
+    this.#source = source;
+    this.#rootPath = rootPath;
+  }
+
+  runUpdateSegments() {
+    return (this.#loadPromise ??= (async () => {
+      if (this.#delegate) {
+        await this.#delegate.runUpdateSegments();
+        this.segments = this.#delegate.segments;
+        return;
+      }
+
+      const loaded = await loadPlaylistText(this.#source, this.#rootPath);
+      const lines = splitPlaylistLines(loaded.text);
+
+      if (lines[0] === '#EXTM3U') {
+        this.#delegate = new HlsSubtitlePlaylist(this.#source, loaded.path);
+        await this.#delegate.runUpdateSegments();
+        this.segments = this.#delegate.segments;
+        return;
+      }
+
+      const segment: HlsSegment = {
+        timestamp: 0,
+        duration: 0,
+        relativeToUnixEpoch: false,
+        firstSegment: null,
+        sequenceNumber: 0,
+        location: {
+          path: toSegmentPath(loaded.path),
+          offset: 0,
+          length: null,
+        },
+        encryption: null,
+        initSegment: null,
+        lastProgramDateTimeSeconds: null,
+      };
+
+      segment.firstSegment = segment;
+      this.segments = [segment];
+      this.#delegate = {
+        segments: this.segments,
+        runUpdateSegments: async () => {},
+        getDurationFromMetadata: async (_options) => null,
+        getLiveRefreshInterval: async () => null,
+        isRelativeToUnixEpoch: async () => false,
+      };
+    })().finally(() => {
+      this.#loadPromise = null;
+    }));
+  }
+
+  async getDurationFromMetadata(options: DurationMetadataRequestOptions) {
+    await this.runUpdateSegments();
+    if (this.#delegate) {
+      return this.#delegate.getDurationFromMetadata(options);
+    }
+    return null;
+  }
+
+  async getLiveRefreshInterval() {
+    await this.runUpdateSegments();
+    if (this.#delegate) {
+      return this.#delegate.getLiveRefreshInterval();
+    }
+    return null;
+  }
+
+  async isRelativeToUnixEpoch() {
+    await this.runUpdateSegments();
+    if (this.#delegate) {
+      return this.#delegate.isRelativeToUnixEpoch();
+    }
+    return false;
+  }
+}
+
 export class HlsSubtitleTrackBacking {
   #id: number;
   #number: number;
@@ -753,6 +844,173 @@ export class HlsSubtitleTrackBacking {
 
   getMetadataCodecParameterString() {
     return this.#track.codecString;
+  }
+
+  async getFirstPacket(_options: unknown): Promise<EncodedPacket | null> {
+    return null;
+  }
+
+  async getPacket(_timestamp: number, _options: unknown): Promise<EncodedPacket | null> {
+    return null;
+  }
+
+  async getNextPacket(_packet: EncodedPacket, _options: unknown): Promise<EncodedPacket | null> {
+    return null;
+  }
+
+  async getKeyPacket(_timestamp: number, _options: unknown): Promise<EncodedPacket | null> {
+    return null;
+  }
+
+  async getNextKeyPacket(_packet: EncodedPacket, _options: unknown): Promise<EncodedPacket | null> {
+    return null;
+  }
+
+  getSegmentedInput() {
+    return this.#segmentedInput;
+  }
+}
+
+export class ExternalSubtitleTrackBacking {
+  #id: number;
+  #number: number;
+  #pairingMask: bigint;
+  #source: SourceWithRootPath;
+  #segmentedInput: ExternalSubtitleSegmentedInput;
+  #languageCode: string;
+  #name: string | null;
+  #disposition: TrackDisposition;
+  #codec: SubtitleCodec | null | undefined;
+  #codecString: string | null | undefined;
+  #codecInfoPromise: Promise<{
+    codec: SubtitleCodec;
+    codecString: string;
+  }> | null = null;
+
+  constructor(params: {
+    id: number;
+    number: number;
+    pairingMask: bigint;
+    source: SourceWithRootPath;
+    codec?: SubtitleCodec | null;
+    codecString?: string | null;
+    languageCode?: string;
+    name?: string | null;
+    disposition?: Partial<TrackDisposition>;
+  }) {
+    this.#id = params.id;
+    this.#number = params.number;
+    this.#pairingMask = params.pairingMask;
+    this.#source = params.source;
+    this.#segmentedInput = new ExternalSubtitleSegmentedInput(
+      params.source,
+      params.source.rootPath,
+    );
+    this.#languageCode = params.languageCode ?? 'und';
+    this.#name = params.name ?? null;
+    this.#codec = params.codec ?? tryParseSubtitleCodec(params.codecString ?? '') ?? undefined;
+    this.#codecString = params.codecString ?? params.codec ?? undefined;
+    this.#disposition = {
+      ...DEFAULT_TRACK_DISPOSITION,
+      ...params.disposition,
+    };
+  }
+
+  getType() {
+    return 'subtitle' as const;
+  }
+
+  getId() {
+    return this.#id;
+  }
+
+  getNumber() {
+    return this.#number;
+  }
+
+  async #getCodecInfo() {
+    if (this.#codec !== undefined && this.#codecString !== undefined) {
+      return {
+        codec: this.#codec,
+        codecString: this.#codecString,
+      };
+    }
+
+    const info = await (this.#codecInfoPromise ??= detectSubtitleCodecFromUri(
+      this.#source,
+      this.#source.rootPath,
+    ));
+    this.#codec = info.codec;
+    this.#codecString = info.codecString;
+    return info;
+  }
+
+  getCodec() {
+    if (this.#codec !== undefined) {
+      return this.#codec as never;
+    }
+
+    return this.#getCodecInfo().then((info) => info.codec as never);
+  }
+
+  getInternalCodecId() {
+    return null;
+  }
+
+  getName() {
+    return this.#name;
+  }
+
+  getLanguageCode() {
+    return this.#languageCode;
+  }
+
+  getTimeResolution() {
+    return 1000;
+  }
+
+  isRelativeToUnixEpoch() {
+    return this.#segmentedInput.isRelativeToUnixEpoch();
+  }
+
+  getDisposition() {
+    return this.#disposition;
+  }
+
+  getPairingMask() {
+    return this.#pairingMask;
+  }
+
+  getBitrate() {
+    return null;
+  }
+
+  getAverageBitrate() {
+    return null;
+  }
+
+  getDurationFromMetadata(options: DurationMetadataRequestOptions) {
+    return this.#segmentedInput.getDurationFromMetadata(options);
+  }
+
+  getLiveRefreshInterval() {
+    return this.#segmentedInput.getLiveRefreshInterval();
+  }
+
+  getHasOnlyKeyPackets() {
+    return true;
+  }
+
+  async getDecoderConfig() {
+    return null;
+  }
+
+  async getMetadataCodecParameterString() {
+    if (this.#codecString !== undefined) {
+      return this.#codecString;
+    }
+
+    return this.#getCodecInfo().then((info) => info.codecString);
   }
 
   async getFirstPacket(_options: unknown): Promise<EncodedPacket | null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,11 @@ import type { DashSegment, DashSegmentedInput } from './dash/dash-segmented-inpu
 import {
   SegmentedMediabunnyInput,
   type MediabunnyAudioTrackWithSegments,
+  type MediabunnySubtitleTrackWithSegments,
   type MediabunnyTrackWithSegments,
   type MediabunnyVideoTrackWithSegments,
+  type InputSubtitleSource,
+  type InputSubtitleTrackMetadata,
   preserveSubtitleBackingsOnInput,
 } from './mediabunny-input';
 
@@ -20,6 +23,7 @@ export type InputSegmentedInput = HlsSegmentedInput | DashSegmentedInput;
 export type InputTrack = MediabunnyTrackWithSegments;
 export type InputVideoTrack = MediabunnyVideoTrackWithSegments;
 export type InputAudioTrack = MediabunnyAudioTrackWithSegments;
+export type InputSubtitleTrack = MediabunnySubtitleTrackWithSegments;
 
 export class Input<S extends Source = Source> extends SegmentedMediabunnyInput<S> {
   constructor(options: DashaInputOptions<S>) {
@@ -38,6 +42,7 @@ export const getSegments = async (track: InputTrack): Promise<InputSegment[]> =>
 export { FilePathSource, UrlSource, HLS_FORMATS, DASH, DASH_FORMATS, desc, asc, prefer };
 export { preserveSubtitleBackingsOnInput };
 export type { MediaCodec, SubtitleCodec } from './codec';
+export type { InputSubtitleSource, InputSubtitleTrackMetadata };
 export type {
   HlsSegment,
   HlsSegmentedInput,

--- a/src/mediabunny-input.ts
+++ b/src/mediabunny-input.ts
@@ -1,16 +1,29 @@
-import { HLS, Input as MediabunnyInput, InputTrack as MediabunnyInputTrack } from 'mediabunny';
+import {
+  HLS,
+  Input as MediabunnyInput,
+  InputTrack as MediabunnyInputTrack,
+  SourceRef,
+} from 'mediabunny';
 import type {
   InputAudioTrack as MediabunnyInputAudioTrack,
   EncodedPacket,
   MediaCodec,
   PacketType,
+  PathedSource,
+  TrackDisposition,
   InputVideoTrack as MediabunnyInputVideoTrack,
   Source,
 } from 'mediabunny';
 import type { HlsSegment, HlsSegmentedInput, InputTrackWithBacking } from './mediabunny';
 import type { DashSegment, DashSegmentedInput } from './dash/dash-segmented-input';
 import type { InputTrackQuery } from 'mediabunny';
-import { getHlsSubtitleTrackBackings, HlsSubtitleTrackBacking } from './hls/hls-subtitles';
+import {
+  ExternalSubtitleTrackBacking,
+  getHlsSubtitleTrackBackings,
+  HlsSubtitleTrackBacking,
+  type SourceWithRootPath,
+} from './hls/hls-subtitles';
+import type { SubtitleCodec } from './codec';
 
 declare module 'mediabunny' {
   interface Input<S extends Source = Source> {
@@ -27,13 +40,25 @@ type SegmentAccessMethods = {
 export type MediabunnyTrackWithSegments = MediabunnyInputTrack & SegmentAccessMethods;
 export type MediabunnyVideoTrackWithSegments = MediabunnyInputVideoTrack & SegmentAccessMethods;
 export type MediabunnyAudioTrackWithSegments = MediabunnyInputAudioTrack & SegmentAccessMethods;
+export type MediabunnySubtitleTrackWithSegments = MediabunnyInputSubtitleTrack &
+  SegmentAccessMethods;
 
-type NativeTrackBacking = Parameters<MediabunnyInput<Source>['_wrapBackingAsTrack']>[0];
+export type InputSubtitleSource = PathedSource | SourceRef<PathedSource>;
+export type InputSubtitleTrackMetadata = {
+  codec?: SubtitleCodec | null;
+  codecString?: string | null;
+  disposition?: Partial<TrackDisposition>;
+  languageCode?: string;
+  name?: string | null;
+  pairWith?: MediabunnyVideoTrackWithSegments | Iterable<MediabunnyVideoTrackWithSegments>;
+};
+
 type InternalInput<S extends Source = Source> = MediabunnyInput<S> & {
   _getTrackBackings(): Promise<NativeTrackBacking[]>;
   _getSyntheticTrackBackings?(
     type?: typeof BACKING_TYPE_VIDEO | typeof BACKING_TYPE_AUDIO | typeof BACKING_TYPE_SUBTITLE,
   ): Promise<TrackBacking[]>;
+  _sourceRefs: SourceRef[];
 };
 
 type SegmentableBacking = {
@@ -61,7 +86,13 @@ type SegmentableBacking = {
   getMetadataCodecParameterString?(): string | null | Promise<string | null>;
   getSegmentedInput?(): HlsSegmentedInput | DashSegmentedInput;
 };
+type NativeTrackBacking = SegmentableBacking;
 type TrackBacking = NativeTrackBacking | SegmentableBacking;
+
+const CUSTOM_SUBTITLE_TRACK_ID_OFFSET = 1_000_000_000;
+const CUSTOM_PAIRING_BIT_START = 1024n;
+const EXTRA_PAIRING_MASK = Symbol.for('dasha.extra-pairing-mask');
+const ORIGINAL_GET_PAIRING_MASK = Symbol.for('dasha.original-get-pairing-mask');
 
 const requireSync = <T>(value: T | Promise<T>, getterName: string, asyncName: string): T => {
   if (value instanceof Promise) {
@@ -128,8 +159,9 @@ const getTrackBackingsByType = async (
   input: InternalInput,
   type?: typeof BACKING_TYPE_VIDEO | typeof BACKING_TYPE_AUDIO | typeof BACKING_TYPE_SUBTITLE,
 ) => {
-  const nativeBackings = await input._getTrackBackings();
-  const syntheticBackings = (await input._getSyntheticTrackBackings?.(type)) ?? [];
+  const nativeBackings = (await input._getTrackBackings()) as TrackBacking[];
+  const syntheticBackings = ((await input._getSyntheticTrackBackings?.(type)) ??
+    []) as TrackBacking[];
   const backings = [...nativeBackings, ...syntheticBackings];
   return type ? backings.filter((backing) => getBackingType(backing) === type) : backings;
 };
@@ -252,13 +284,18 @@ export class SegmentedMediabunnyInput<S extends Source = Source> extends Mediabu
   #trackCache = new WeakMap<MediabunnyInputTrack, MediabunnyTrackWithSegments>();
   #subtitleTrackCache = new WeakMap<object, MediabunnyInputSubtitleTrack>();
   #hlsSubtitleBackingsPromise: Promise<HlsSubtitleTrackBacking[]> | null = null;
+  #customSubtitleBackings: ExternalSubtitleTrackBacking[] = [];
+  #nextCustomSubtitleTrackId = CUSTOM_SUBTITLE_TRACK_ID_OFFSET;
+  #nextCustomSubtitleTrackNumber = CUSTOM_SUBTITLE_TRACK_ID_OFFSET;
+  #nextPairingBitIndex: bigint | null = null;
 
   async #queryTracks<T extends MediabunnyInputTrack>(
     query: InputTrackQuery<T> | undefined,
     type?: typeof BACKING_TYPE_VIDEO | typeof BACKING_TYPE_AUDIO | typeof BACKING_TYPE_SUBTITLE,
   ) {
-    const backings = await getTrackBackingsByType(this as InternalInput<S>, type);
-    return queryWrappedTracks(this as InternalInput<S>, backings, query);
+    const internalInput = this as unknown as InternalInput<S>;
+    const backings = await getTrackBackingsByType(internalInput, type);
+    return queryWrappedTracks(internalInput, backings, query);
   }
 
   override _wrapBackingAsTrack(backing: TrackBacking): MediabunnyTrackWithSegments {
@@ -281,8 +318,9 @@ export class SegmentedMediabunnyInput<S extends Source = Source> extends Mediabu
       return [];
     }
 
+    const backings = [...this.#customSubtitleBackings];
     if ((await this.getFormat()) !== HLS) {
-      return [];
+      return backings;
     }
 
     if (!this.#hlsSubtitleBackingsPromise) {
@@ -295,7 +333,7 @@ export class SegmentedMediabunnyInput<S extends Source = Source> extends Mediabu
       this.#hlsSubtitleBackingsPromise = promise;
     }
 
-    return this.#hlsSubtitleBackingsPromise;
+    return [...backings, ...(await this.#hlsSubtitleBackingsPromise)];
   }
 
   #wrapSubtitleBacking(backing: SegmentableBacking) {
@@ -325,6 +363,13 @@ export class SegmentedMediabunnyInput<S extends Source = Source> extends Mediabu
     )) as MediabunnyAudioTrackWithSegments[];
   }
 
+  async getSubtitleTracks(query?: InputTrackQuery<MediabunnySubtitleTrackWithSegments>) {
+    return (await this.#queryTracks(
+      query,
+      BACKING_TYPE_SUBTITLE,
+    )) as MediabunnySubtitleTrackWithSegments[];
+  }
+
   override async getPrimaryVideoTrack(query?: InputTrackQuery<MediabunnyVideoTrackWithSegments>) {
     return (await super.getPrimaryVideoTrack(
       query as never,
@@ -335,5 +380,137 @@ export class SegmentedMediabunnyInput<S extends Source = Source> extends Mediabu
     return (await super.getPrimaryAudioTrack(
       query as never,
     )) as MediabunnyAudioTrackWithSegments | null;
+  }
+
+  addSubtitleTrack(
+    source: InputSubtitleSource,
+    metadata: InputSubtitleTrackMetadata = {},
+  ): MediabunnySubtitleTrackWithSegments {
+    const pathedSource = this.#takeSubtitleSourceRef(source);
+    const sourceWithRootPath = pathedSource.source as SourceWithRootPath;
+    if (typeof sourceWithRootPath.rootPath !== 'string') {
+      throw new TypeError('source must provide a string rootPath.');
+    }
+
+    const pairWith = this.#toPairableVideoTracks(metadata.pairWith);
+    const backing = new ExternalSubtitleTrackBacking({
+      id: this.#nextCustomSubtitleTrackId++,
+      number: this.#nextCustomSubtitleTrackNumber++,
+      pairingMask: 0n,
+      source: sourceWithRootPath,
+      codec: metadata.codec,
+      codecString: metadata.codecString,
+      disposition: metadata.disposition,
+      languageCode: metadata.languageCode,
+      name: metadata.name,
+    });
+
+    this.#pairSubtitleBacking(backing, pairWith);
+    this.#customSubtitleBackings.push(backing);
+    return this._wrapBackingAsTrack(backing) as MediabunnySubtitleTrackWithSegments;
+  }
+
+  #takeSubtitleSourceRef(source: InputSubtitleSource) {
+    const rawSource = source instanceof SourceRef ? source.source : source;
+    if (
+      !(rawSource instanceof Object) ||
+      !('rootPath' in rawSource) ||
+      !('ref' in rawSource) ||
+      typeof rawSource.ref !== 'function'
+    ) {
+      throw new TypeError('source must be a pathed source such as UrlSource or FilePathSource.');
+    }
+
+    const ref = rawSource.ref() as SourceRef<PathedSource>;
+    (this as unknown as InternalInput<S>)._sourceRefs.push(ref);
+    return ref;
+  }
+
+  #toPairableVideoTracks(
+    pairWith:
+      | MediabunnyVideoTrackWithSegments
+      | Iterable<MediabunnyVideoTrackWithSegments>
+      | undefined,
+  ) {
+    if (!pairWith) {
+      return [];
+    }
+
+    const tracks = this.#isIterable(pairWith) ? [...pairWith] : [pairWith];
+    for (const track of tracks) {
+      if (track.input !== this) {
+        throw new TypeError('pairWith tracks must belong to the same input instance.');
+      }
+      if (track.type !== 'video') {
+        throw new TypeError('pairWith only accepts video tracks.');
+      }
+    }
+    return tracks;
+  }
+
+  #isIterable<T>(value: Iterable<T> | T): value is Iterable<T> {
+    return typeof value === 'object' && value !== null && Symbol.iterator in value;
+  }
+
+  #pairSubtitleBacking(
+    subtitleBacking: ExternalSubtitleTrackBacking,
+    videoTracks: MediabunnyVideoTrackWithSegments[],
+  ) {
+    for (const track of videoTracks) {
+      const bit = this.#allocatePairingBit();
+      this.#appendPairingMask(subtitleBacking as TrackBacking, bit);
+      this.#appendPairingMask(
+        (track as unknown as MediabunnyInputTrack & { _backing: TrackBacking })._backing,
+        bit,
+      );
+    }
+  }
+
+  #allocatePairingBit() {
+    const nextIndex = this.#nextPairingBitIndex ?? this.#getInitialPairingBitIndex();
+    this.#nextPairingBitIndex = nextIndex + 1n;
+    return 1n << nextIndex;
+  }
+
+  #getInitialPairingBitIndex() {
+    const internalInput = this as unknown as InternalInput<S> & {
+      _trackBackingsCache?: NativeTrackBacking[] | null;
+    };
+    const loadedBackings: TrackBacking[] = [...(internalInput._trackBackingsCache ?? [])];
+    let maxBitIndex = -1n;
+
+    for (const backing of [...loadedBackings, ...this.#customSubtitleBackings]) {
+      const mask = backing.getPairingMask?.() ?? 0n;
+      if (mask === 0n) {
+        continue;
+      }
+
+      const bitIndex = BigInt(mask.toString(2).length - 1);
+      if (bitIndex > maxBitIndex) {
+        maxBitIndex = bitIndex;
+      }
+    }
+
+    return maxBitIndex >= 0n ? maxBitIndex + 1n : CUSTOM_PAIRING_BIT_START;
+  }
+
+  #appendPairingMask(backing: TrackBacking, mask: bigint) {
+    const patchedBacking = backing as TrackBacking & {
+      [EXTRA_PAIRING_MASK]?: bigint;
+      [ORIGINAL_GET_PAIRING_MASK]?: () => bigint;
+    };
+
+    patchedBacking[EXTRA_PAIRING_MASK] = (patchedBacking[EXTRA_PAIRING_MASK] ?? 0n) | mask;
+    if (patchedBacking[ORIGINAL_GET_PAIRING_MASK]) {
+      return;
+    }
+
+    const originalGetPairingMask = backing.getPairingMask?.bind(backing) ?? (() => 0n);
+    patchedBacking[ORIGINAL_GET_PAIRING_MASK] = originalGetPairingMask;
+    Object.assign(backing, {
+      getPairingMask: () =>
+        (patchedBacking[ORIGINAL_GET_PAIRING_MASK]?.() ?? 0n) |
+        (patchedBacking[EXTRA_PAIRING_MASK] ?? 0n),
+    });
   }
 }

--- a/test/input-external-subtitles.test.ts
+++ b/test/input-external-subtitles.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest';
+import { DASH_FORMATS, FilePathSource } from '../src';
+import { createAssetInput, assetPath, assetFileUrl } from './utils';
+
+test('addSubtitleTrack adds direct subtitle files to the input query API', async () => {
+  using input = createAssetInput('bitmovin.mpd', DASH_FORMATS);
+
+  const addedTrack = input.addSubtitleTrack(
+    new FilePathSource(assetPath('hls-subtitles-en-0001.srt')),
+    {
+      languageCode: 'en',
+      name: 'English',
+      disposition: {
+        default: false,
+        forced: true,
+      },
+    },
+  );
+
+  expect(await addedTrack.getCodec()).toBe('srt');
+  expect(await addedTrack.getLanguageCode()).toBe('en');
+  expect(await addedTrack.getName()).toBe('English');
+  await expect(addedTrack.getDisposition()).resolves.toMatchObject({
+    default: false,
+    forced: true,
+  });
+
+  const subtitleTracks = await input.getSubtitleTracks({
+    filter: async (track) => (await track.getLanguageCode()) === 'en',
+  });
+  expect(subtitleTracks).toHaveLength(1);
+  expect(subtitleTracks[0]).toBe(addedTrack);
+
+  const segments = await addedTrack.getSegments();
+  expect(segments).toHaveLength(1);
+  expect(segments[0]?.location.path).toBe(assetFileUrl('hls-subtitles-en-0001.srt'));
+});
+
+test('addSubtitleTrack can pair external subtitles with selected video tracks', async () => {
+  using input = createAssetInput('bitmovin.mpd', DASH_FORMATS);
+
+  const primaryVideoTrack = await input.getPrimaryVideoTrack();
+  const primaryAudioTrack = await input.getPrimaryAudioTrack();
+
+  expect(primaryVideoTrack).not.toBeNull();
+  expect(primaryAudioTrack).not.toBeNull();
+
+  const addedTrack = input.addSubtitleTrack(
+    new FilePathSource(assetPath('hls-subtitles-srt.m3u8')),
+    {
+      languageCode: 'en',
+      pairWith: primaryVideoTrack!,
+    },
+  );
+
+  expect(await addedTrack.getCodec()).toBe('srt');
+
+  const pairableVideoTracks = await addedTrack.getPairableVideoTracks();
+  expect(pairableVideoTracks).toHaveLength(1);
+  expect(pairableVideoTracks[0]).toBe(primaryVideoTrack);
+
+  await expect(addedTrack.getPairableAudioTracks()).resolves.toEqual([]);
+
+  const segments = await addedTrack.getSegments();
+  expect(segments).toHaveLength(2);
+  expect(segments[0]?.location.path).toBe(assetFileUrl('hls-subtitles-en-0001.srt'));
+  expect(segments[1]?.location.path).toBe(assetFileUrl('hls-subtitles-en-0002.srt'));
+});


### PR DESCRIPTION
## Summary
- Added `Input.addSubtitleTrack()` and `Input.getSubtitleTracks()` on top of the existing mediabunny-compatible query flow.
- External subtitles now support pairing against selected video tracks, so they participate in `canBePairedWith()` and related track selection logic.
- Extended subtitle backing support to handle direct subtitle files and HLS subtitle playlists without touching mediabunny core.
- Added tests covering direct subtitle files, playlist-based subtitles, and pairing behavior.

## Testing
- `pnpm typecheck`
- `pnpm vitest run`
- `pnpm exec oxfmt --check src/hls/hls-subtitles.ts src/mediabunny-input.ts`