### PR TITLE
Cache segment reads and add explicit refresh APIs

### DIFF
--- a/src/dash/dash-demuxer.ts
+++ b/src/dash/dash-demuxer.ts
@@ -1348,6 +1348,14 @@ abstract class DashTrackBackingBase {
 
   async getSegments(): Promise<DashSegment[]> {
     const segmentedInput = this.getSegmentedInput();
+    if (segmentedInput.segments.length === 0) {
+      await segmentedInput.runUpdateSegments();
+    }
+    return segmentedInput.segments;
+  }
+
+  async refreshSegments(): Promise<DashSegment[]> {
+    const segmentedInput = this.getSegmentedInput();
     await segmentedInput.runUpdateSegments();
     return segmentedInput.segments;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,6 @@ export const isInput = (value: unknown): value is Input => value instanceof Inpu
 export const getSegmentedInput = (track: InputTrack): InputSegmentedInput =>
   track.getSegmentedInput();
 
-export const getSegments = async (track: InputTrack): Promise<InputSegment[]> =>
-  track.getSegments();
-
 const ALL_FORMATS = [...ALL_MEDIABUNNY_FORMATS, DASH];
 
 export { DASH, DASH_FORMATS, ALL_FORMATS };

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,6 @@ export class Input<S extends Source = Source> extends SegmentedMediabunnyInput<S
 
 export const isInput = (value: unknown): value is Input => value instanceof Input;
 
-export const getSegmentedInput = (track: InputTrack): InputSegmentedInput =>
-  track.getSegmentedInput();
-
 const ALL_FORMATS = [...ALL_MEDIABUNNY_FORMATS, DASH];
 
 export { DASH, DASH_FORMATS, ALL_FORMATS };

--- a/src/mediabunny-input.ts
+++ b/src/mediabunny-input.ts
@@ -38,6 +38,7 @@ declare module 'mediabunny' {
 type SegmentAccessMethods = {
   getSegmentedInput(): HlsSegmentedInput | DashSegmentedInput;
   getSegments(): Promise<(HlsSegment | DashSegment)[]>;
+  refreshSegments(): Promise<(HlsSegment | DashSegment)[]>;
 };
 
 type TrackMetadataOverrideMethods = {
@@ -492,6 +493,16 @@ const addSegmentAccess = <T extends MediabunnyInputTrack>(
       }
 
       if (prop === 'getSegments') {
+        return async () => {
+          const segmentedInput = getSegmentedInputForTrack(target);
+          if (segmentedInput.segments.length === 0) {
+            await segmentedInput.runUpdateSegments();
+          }
+          return segmentedInput.segments;
+        };
+      }
+
+      if (prop === 'refreshSegments') {
         return async () => {
           const segmentedInput = getSegmentedInputForTrack(target);
           await segmentedInput.runUpdateSegments();

--- a/test/dash.test.ts
+++ b/test/dash.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { InputFormat } from 'mediabunny';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { DASH, DASH_FORMATS, Input, UrlSource, desc, isInput } from '../src';
 
 test('parse dash with the mediabunny-like input API', async () => {
@@ -38,4 +38,28 @@ test('parse dash with the mediabunny-like input API', async () => {
   expect(segments[0]?.initSegment?.location.path).toBe(initUrl);
   expect(segments[0]?.location.path).toBe(firstSegmentUrl);
   expect(segments[2]?.location.path).toBe(thirdSegmentUrl);
+});
+
+test('getSegments returns cached dash segments unless explicitly refreshed', async () => {
+  const manifestPath = path.resolve('test/fixtures/sample.mpd');
+  const manifestUrl = pathToFileURL(manifestPath).toString();
+
+  using input = new Input({
+    source: new UrlSource(manifestUrl),
+    formats: DASH_FORMATS,
+  });
+
+  const videoTracks = await input.getVideoTracks();
+  const track = videoTracks[0];
+  const initialSegments = await track.getSegments();
+  const segmentedInput = track.getSegmentedInput();
+  const runUpdateSegments = vi.spyOn(segmentedInput, 'runUpdateSegments');
+
+  const cachedSegments = await track.getSegments();
+  expect(cachedSegments).toBe(initialSegments);
+  expect(runUpdateSegments).not.toHaveBeenCalled();
+
+  const refreshedSegments = await track.refreshSegments();
+  expect(refreshedSegments).toBe(segmentedInput.segments);
+  expect(runUpdateSegments).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Summary
- Make `getSegments()` return cached segments when they already exist, and only trigger the initial load when the list is empty.
- Add `refreshSegments()` for callers that need a forced update.
- Update the DASH track path and the exported helpers to match the split behavior.
- Add a unit test covering cached reads versus explicit refresh.

## Testing
- Unit tests added for cached `getSegments()` behavior and `refreshSegments()` forcing an update.